### PR TITLE
Fix Get-S3Object: Directory not found

### DIFF
--- a/src/S3-Client.psm1
+++ b/src/S3-Client.psm1
@@ -7896,6 +7896,10 @@ function Global:Read-S3Object {
         $StartTime = Get-Date
         Write-Progress -Activity "Uploading file $($InFile.Name) to $BucketName/$Key" -Status "0 MiB written (0% Complete) / 0 MiB/s / estimated time to completion: 0" -PercentComplete 0
 
+		if(!(Test-Path $(Split-Path $OutFile))){
+			New-Item $(Split-Path $OutFile) -ItemType Directory | Out-Null
+		}
+
         Write-Debug "Create new file of size $Size"
         $FileStream = [System.IO.FileStream]::new($OutFile,[System.IO.FileMode]::OpenOrCreate,[System.IO.FileAccess]::Write,[System.IO.FileShare]::None)
         $FileStream.setLength($Size)


### PR DESCRIPTION
Fixing Error for Get-S3Object with -Path Parameter

Exception calling ".ctor" with "4" argument(s): "Could not find a part of the path
'C:\temp\c24a2eaf-ab5e-430a-9111-fe04ec56f831\062adf21_0000000000001903_c24a2eaf-ab5e-430a-9111-fe04ec56f831'."
At C:\Program Files\WindowsPowerShell\Modules\S3-Client\1.9.0\S3-Client.psm1:7901 char:9
+         $FileStream = [System.IO.FileStream]::new($OutFile,[System.IO ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : DirectoryNotFoundException